### PR TITLE
fix: --out with --module

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,12 @@ function tsc(input, output, options, callback, log) {
 		output = input.replace(/\.ts$/, '.js');
 	}
 
-	var args = _.extend({}, options, {out: output});
+	var args = _.clone(options);
+
+	if (!('module' in args)) {
+		args.out = output;
+	}
+
 	var opts = {files: [input], args: args};
 
 	if (options.compiler) {


### PR DESCRIPTION
Now the `output` filename is only attached to the `args` Object when no `module` property has been specified.

Closes: #13
