### PR TITLE
fix: add typescript to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,21 +20,21 @@
     "Keats <balthek@gmail.com>"
   ],
   "dependencies": {
+    "lodash": "~2.4.1",
     "node-tsc": "0.0.9",
-    "lodash": "~2.4.1"
+    "typescript": "^1.3.0"
   },
   "devDependencies": {
-    "typescript": "^1.3",
     "grunt": "~0.4",
+    "grunt-auto-release": "~0.0.6",
+    "grunt-bump": "~0.0.7",
+    "grunt-cli": "~0.1",
+    "grunt-coffeelint": "0.0.13",
     "grunt-contrib-jshint": "~0.10",
     "grunt-npm": "~0.0.2",
-    "grunt-bump": "~0.0.7",
-    "grunt-auto-release": "~0.0.6",
-    "grunt-coffeelint": "0.0.13",
-    "grunt-cli": "~0.1",
     "karma": "~0.12",
-    "karma-jasmine": "~0.3",
     "karma-chrome-launcher": "~0.1",
+    "karma-jasmine": "~0.3",
     "karma-phantomjs-launcher": "~0.1"
   },
   "scripts": {


### PR DESCRIPTION
Most of this diff is causes by sorting the dependencies alphabetically.

Closes #19
