### PR TITLE
Add option to pass additional typing definitions to typescript compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ module.exports = function(config) {
         noResolve: true, // (optional) Skip resolution and preprocessing.
         removeComments: true // (optional) Do not emit comments to output.
       },
+      // extra typing definitions to pass to the compiler (globs allowed)
+      typings: [
+        'typings/tsd.d.ts'
+      ],
       // transforming the filenames
       transformPath: function(path) {
         return path.replace(/\.ts$/, '.js');

--- a/package.json
+++ b/package.json
@@ -24,18 +24,19 @@
     "lodash": "~3.5.0"
   },
   "devDependencies": {
-    "typescript": "^1.4",
+    "glob": "^5.0.5",
     "grunt": "~0.4",
+    "grunt-auto-release": "~0.0.6",
+    "grunt-bump": "~0.3.0",
+    "grunt-cli": "~0.1",
+    "grunt-coffeelint": "0.0.13",
     "grunt-contrib-jshint": "~0.11",
     "grunt-npm": "~0.0.2",
-    "grunt-bump": "~0.3.0",
-    "grunt-auto-release": "~0.0.6",
-    "grunt-coffeelint": "0.0.13",
-    "grunt-cli": "~0.1",
     "karma": "~0.12",
-    "karma-jasmine": "~0.3",
     "karma-chrome-launcher": "~0.1",
-    "karma-phantomjs-launcher": "~0.1"
+    "karma-jasmine": "~0.3",
+    "karma-phantomjs-launcher": "~0.1",
+    "typescript": "^1.4"
   },
   "scripts": {
     "lint": "grunt lint",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -11,6 +11,9 @@ module.exports = function(config) {
 		},
 
 		typescriptPreprocessor: {
+			typings: [
+				'../typings/jasmine/*.d.ts'
+			],
 			options: {
 				sourceMap: true
 			}

--- a/test/spec1.ts
+++ b/test/spec1.ts
@@ -1,4 +1,3 @@
-/// <reference path="../typings/jasmine/jasmine.d.ts"/>
 /// <reference path="src/person.ts"/>
 
 function greeter(person : Person) {


### PR DESCRIPTION
Currently every file compiled by the preprocessor has to reference typing definitions via a `/// <reference>` or Typescript will output a ton of errors. This change allows global type defs to be identified so the compiler can infer those types without verbose and redundant references in the sources.