### PR TITLE
Support for *.tsx files in TypeScript 1.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ function sourceMapAsDataUri(content, file, callback) {
 
 function tsc(file, content, typings, options, callback, log) {
 	var args = _.clone(options);
-	var input  = file.originalPath + '.ktp.ts';
+	var inputExtension = file.originalPath.split('.').pop();
+	var input  = file.originalPath + '.ktp.' + inputExtension;
 	var output = file.originalPath + '.ktp.js';
 	file.outputPath = output + '.ktp.js';
 	file.sourceMapPath = output + '.map';


### PR DESCRIPTION
TypeScript 1.6.0 introduces option to compile `*.tsx` files.

Files made for compilation in preprocessor have hardcoded `*.ts` extensions. TypeScript compiler expects extension to be `*.tsx` to enable usage of `--jsx` option.

This pull request contains fix that works by providing original extension to input file.