### PR TITLE
Added option to control output file concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ module.exports = function(config) {
         noImplicitAny: true, // (optional) Warn on expressions and declarations with an implied 'any' type.
         noResolve: true, // (optional) Skip resolution and preprocessing.
         removeComments: true // (optional) Do not emit comments to output.
+        concatinateOutput: false // (optional) Concatenate and emit output to single file. By default true if module option is omited, otherwise false.
       },
       // extra typing definitions to pass to the compiler (globs allowed)
       typings: [

--- a/index.js
+++ b/index.js
@@ -72,10 +72,11 @@ function tsc(file, content, typings, options, callback, log) {
 	var inputExtension = file.originalPath.split('.').pop();
 	var input  = file.originalPath + '.ktp.' + inputExtension;
 	var output = file.originalPath + '.ktp.js';
+	var concatinateOutput = args.concatinateOutput !== undefined ? args.concatinateOutput : !('module' in args);
 	file.outputPath = output + '.ktp.js';
 	file.sourceMapPath = output + '.map';
 
-	if (!('module' in args)) {
+	if (concatinateOutput) {
 		args.out = output;
 	}
 


### PR DESCRIPTION
When `module` option is omitted `--outFile` (`--out`) is automatically set.

This merge request introduces option `concatinateOutput` to have control over this behaviour.

**Use case scenario:**
When using `--target ES6` TypeScript will throw error that `module` should not be used for ES6. And removing `module` option causes `--outFile` to be set which overwrites original compilation output with dependencies that should have been referenced with triple slashes, resulting in empty result file.