### PR TITLE
Fix unmet peer dependencies error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "glob": "^5.0.14"
   },
   "devDependencies": {
+    "coffeelint": "^1.15.0",
     "grunt": "~0.4",
     "grunt-auto-release": "~0.0.6",
     "grunt-bump": "~0.6.0",
@@ -34,10 +35,12 @@
     "grunt-coffeelint": "0.0.13",
     "grunt-contrib-jshint": "~0.11",
     "grunt-npm": "~0.0.2",
+    "jasmine-core": "^2.4.1",
     "karma": "~0.13",
     "karma-chrome-launcher": "~0.2",
     "karma-jasmine": "~0.3",
     "karma-phantomjs-launcher": "~0.2",
+    "phantomjs": "^2.1.3",
     "typescript": "^1.5"
   },
   "scripts": {


### PR DESCRIPTION
Hi @sergeyt, This pull request fix error when run `npm install`.

```bash
npm WARN karma-phantomjs-launcher@0.2.3 requires a peer of phantomjs@>=1.9 but none was installed.
npm WARN karma-jasmine@0.3.8 requires a peer of jasmine-core@* but none was installed.
npm WARN grunt-coffeelint@0.0.13 requires a peer of coffeelint@^1 but none was installed.
```