### PR TITLE
feat(config): specify typescript instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var ts = require('typescript');
 var path = require('path');
 
 var createTypeScriptPreprocessor = function(args, config, logger, helper) {
@@ -13,6 +12,7 @@ var createTypeScriptPreprocessor = function(args, config, logger, helper) {
 
 	// compiler options
 	var options = helper.merge(defaultOptions, args.options || {}, config.options || {});
+	var ts = config.typescript || require('typescript');
 
 	return function(content, file, done) {
 		log.debug('Processing "%s".', file.originalPath);


### PR DESCRIPTION
If the developer is using a version of typescript that is different than specified by this plugin, there's no way to provide that. This PR adds a simple configuration option which allows the developer to pass in the compiler instance they wish to use.